### PR TITLE
[FIX] Fix Github Actions which do not work with env variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,5 +43,5 @@ Thumbs.db
 
 # Environments
 /src/environments
-#firbase cache
+# Firebase cache
 /.firebase


### PR DESCRIPTION
# What this PR do ?

- Corrected a small typo in the comment within the `.gitignore` file, in order to trigger the CI. This seems to work.

**Step on my machine**
- `git clone ...`
- `ng generate environments`
_(It generate `environment.ts`, `environment.stating.ts` and `environment.development.ts`)_
- Open Pull Request.